### PR TITLE
feat(exercises): new react syntax

### DIFF
--- a/code/application/client/src/App.js
+++ b/code/application/client/src/App.js
@@ -1,7 +1,7 @@
 import './App.css';
 import 'bootstrap/dist/css/bootstrap.min.css';
 
-import React from 'react';
+import React, { useState } from 'react';
 
 import Navbar from 'react-bootstrap/Navbar';
 import Container from 'react-bootstrap/Container';
@@ -11,128 +11,104 @@ import Col from 'react-bootstrap/Col';
 import OverView from './OverView';
 import UnitView from './UnitView';
 
-class App extends React.Component {
-  constructor() {
-    super();
-    this.state = {
-      overview: "country",
-      overviewName: "Country",
-      overviewCode: "E92000001",
-      overviewChildren: "regions",
-      detail: "",
-      detailName: "",
-      detailCode: ""
-    }
-    this.navigate = this.navigate.bind(this);
-    this.details = this.details.bind(this);
+function App() {
+  const [overview, setOverview] = useState("country");
+  const [overviewName, setOverviewName] = useState("Country");
+  const [overviewCode, setOverviewCode] = useState("E92000001");
+  const [overviewChildren, setOverviewChildren] = useState("regions");
+  const [detail, setDetail] = useState("");
+  const [detailName, setDetailName] = useState("");
+  const [detailCode, setDetailCode] = useState("");
+
+  function details() {
+    console.log("details for " + overview + " " + overviewCode);
+    setDetail(overview);
+    setDetailName(overviewName);
+    setDetailCode(overviewCode);
   }
 
-  details() {
-    console.log("details for " + this.state.overview + " " + this.state.overviewCode);
-    this.setState({
-      detail: this.state.overview,
-      detailName: this.state.overviewName,
-      detailCode: this.state.overviewCode
-    })
-  }
-
-  navigate(code, isParent) {
+  function navigate(code, isParent) {
     // Called when we want to change the main view.
-    switch (this.state.overview) {
+    switch (overview) {
       case "country":
-        // no parent option here
-        this.setState({
-          overview: "region",
-          overviewName: "Region",
-          overviewChildren: "counties",
-          overviewCode: code,
-          detailCode: ""
-        })
+        setOverview("region");
+        setOverviewName("Region");
+        setOverviewChildren("counties");
+        setOverviewCode(code);
+        setDetailCode("");
+        
         break;
       case "region":
         if (isParent) {
-          this.setState({
-            overview: "country",
-            overviewName: "Country",
-            overviewChildren: "regions",
-            overviewCode: code,
-            detailCode: ""
-          })
+          setOverview("country");
+          setOverviewName("Country");
+          setOverviewChildren("regions");
+          setOverviewCode(code);
+          setDetailCode("");
         } else {
-          this.setState({
-            overview: "county",
-            overviewName: "County",
-            overviewChildren: "wards",
-            overviewCode: code,
-            detailCode: ""
-          })
+          setOverview("county");
+          setOverviewName("County");
+          setOverviewChildren("wards");
+          setOverviewCode(code);
+          setDetailCode("");
         }
         break;
       case "county":
         if (isParent) {
-          this.setState({
-            overview: "region",
-            overviewName: "Region",
-            overviewChildren: "counties",
-            overviewCode: code,
-            detailCode: ""
-          })
+          setOverview("region");
+          setOverviewName("Region");
+          setOverviewChildren("counties");
+          setOverviewCode(code);
+          setDetailCode("");
         } else {
-          this.setState({
-            overview: "ward",
-            overviewName: "Ward",
-            overviewChildren: undefined,
-            overviewCode: code,
-            detailCode: ""
-          })
+          setOverview("ward");
+          setOverviewName("Ward");
+          setOverviewChildren(undefined);
+          setOverviewCode(code);
+          setDetailCode("");
         }
         break;
       case "ward":
-        // wards have no children
-        this.setState({
-          overview: "county",
-          overviewName: "County",
-          overviewChildren: "wards",
-          overviewCode: code,
-          detailCode: ""
-        })
+        setOverview("county");
+        setOverviewName("County");
+        setOverviewChildren("wards");
+        setOverviewCode(code);
+        setDetailCode("");
         break;
       default:
           console.log("App.navigate")
     }
   }
 
-  render() {
-    return (
-      <div className="App">
-        <Navbar bg="primary" variant="dark">
-          <Container>
-            <Navbar.Brand href="#home">Census Explorer</Navbar.Brand>
-          </Container>
-        </Navbar>
-        <Container className="mt-2">
-          <Row>
-            <Col>
-              <OverView displayName = {this.state.overviewName}
-                        type = {this.state.overview}
-                        code = {this.state.overviewCode}
-                        children = {this.state.overviewChildren}
-                        callback={this.navigate}
-                        details={this.details}></OverView>
-            </Col>
-            <Col>
-              {
-                this.state.detailCode === "" ? "" :
-                <UnitView displayName={this.state.detailName} 
-                          type={this.state.detail} 
-                          code={this.state.detailCode}></UnitView>
-              }
-            </Col>
-          </Row>
+  return (
+    <div className="App">
+      <Navbar bg="primary" variant="dark">
+        <Container>
+          <Navbar.Brand href="#home">Census Explorer</Navbar.Brand>
         </Container>
-      </div>
-    )
-  }
+      </Navbar>
+      <Container className="mt-2">
+        <Row>
+          <Col>
+            <OverView displayName = {overviewName}
+                      type = {overview}
+                      code = {overviewCode}
+                      children = {overviewChildren}
+                      callback={navigate}
+                      details={details}></OverView>
+          </Col>
+          <Col>
+            {
+              detailCode === "" ? "" :
+              <UnitView displayName={detailName} 
+                        type={detail} 
+                        code={detailCode}></UnitView>
+            }
+          </Col>
+        </Row>
+      </Container>
+    </div>
+  );
 }
 
 export default App;

--- a/code/application/client/src/UnitView.js
+++ b/code/application/client/src/UnitView.js
@@ -1,109 +1,103 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 import Card from 'react-bootstrap/Card';
 
-class UnitView extends React.Component {
-
-    constructor(props) {
-      super(props);
-      this.state = {
-        isLoaded: false,
-        isError: false,
-        item: {}
-      }
-    }
+function UnitView({ displayName, type, code, callback, details, children}) {
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [isError, setIsError] = useState(false);
+  const [item, setItem] = useState({});
+  const [errmsg, setErrmsg] = useState(null);
   
-    _fetchData() {
-      const url = "http://localhost:8000/api/details/" + this.props.type + "/" + this.props.code;
-      console.log("UnitView fetch " + url);
-      fetch(url)
-      .then(r => {
-        if (!r.ok) {
-          const e = "Attempting to load " + r.url + " got status " + r.status + ".";
-          this.setState({isLoaded: true, isError: true, errmsg: e})
+  function _fetchData() {
+    const url = "http://localhost:8000/api/details/" + type + "/" + code;
+    console.log("UnitView fetch " + url);
+    fetch(url)
+    .then(r => {
+      if (!r.ok) {
+        const e = "Attempting to load " + r.url + " got status " + r.status + ".";
+        setIsLoaded(true);
+        setIsError(true);
+        setErrmsg(e);
+      }
+      return r.json()
+    })
+    .then (
+      (result) => {
+        if (!isError) {
+          setIsLoaded(true);
+          setItem(result);
         }
-        return r.json()
-      })
-      .then (
-        (result) => {
-          if (!this.state.isError) {
-            this.setState({isLoaded: true, item: result})
+      },
+      (error) => {
+        setIsLoaded(true);
+        setIsError(true);
+        setErrmsg("Network error");
+      }
+    )
+  }
+
+  useEffect(() => {
+    setIsLoaded(false);
+    setIsError(false);
+    _fetchData();
+  }, [_fetchData]);
+
+    
+  if (isLoaded === false) {
+    return (
+      <Card>
+        <Card.Body>
+          <Card.Text>
+            Loading ...
+          </Card.Text>
+        </Card.Body>
+      </Card>
+    );
+  }
+  if (isError) {
+    return (
+      <Card>
+        <Card.Body>
+          <Card.Title>Error</Card.Title>
+          <Card.Text>
+            An error occurred.
+          </Card.Text>
+        </Card.Body>
+      </Card>
+    );
+  }
+  return (
+    <Card>
+      <Card.Body>
+        <Card.Title>Statistics</Card.Title>
+        <Card.Subtitle className="mb-2 text-muted">for {displayName} {code}</Card.Subtitle>
+        <table className="table table-sm">
+          <thead>
+            <tr>
+              <th>Occupation class</th>
+              <th style={{textAlign: "right"}}>Women</th>
+              <th style={{textAlign: "right"}}>Men</th>
+              <th style={{textAlign: "right"}}>Total</th>
+            </tr>
+          </thead>
+          <tbody>
+          {
+            item.map(i =>
+              <tr key={i.occId}>
+                {
+                  i.occId === 0 ? <th>{i.occName}</th> : <td>{i.occName}</td>
+                }
+                <td style={{textAlign: "right"}}>{i.women}</td>
+                <td style={{textAlign: "right"}}>{i.men}</td>
+                <td style={{textAlign: "right"}}>{i.total}</td>
+              </tr>
+            )
           }
-        },
-        (error) => {
-          this.setState({isLoaded: true, isError: true, errmsg: "Network error"})
-        }
-      )
-    }
-
-    componentDidMount() {
-      this._fetchData();
-    }
-  
-    componentDidUpdate(oldProps) {
-      if (this.props.code !== oldProps.code) {
-        this.setState({isLoaded: false});
-        this._fetchData();
-      }
-    }
-  
-    render() {
-      if (this.state.isLoaded === false) {
-        return (
-          <Card>
-            <Card.Body>
-              <Card.Text>
-                Loading ...
-              </Card.Text>
-            </Card.Body>
-          </Card>
-        )
-      }
-      if (this.state.isError) {
-        return (
-          <Card>
-            <Card.Body>
-              <Card.Title>Error</Card.Title>
-              <Card.Text>
-                An error occurred.
-              </Card.Text>
-            </Card.Body>
-          </Card>
-        )
-      }
-      return (
-        <Card>
-          <Card.Body>
-            <Card.Title>Statistics</Card.Title>
-            <Card.Subtitle className="mb-2 text-muted">for {this.props.displayName} {this.props.code}</Card.Subtitle>
-            <table className="table table-sm">
-              <thead>
-                <tr>
-                  <th>Occupation class</th>
-                  <th style={{textAlign: "right"}}>Women</th>
-                  <th style={{textAlign: "right"}}>Men</th>
-                  <th style={{textAlign: "right"}}>Total</th>
-                </tr>
-              </thead>
-              <tbody>
-              {
-                this.state.item.map(i =>
-                  <tr key={i.occId}>
-                    {
-                      i.occId === 0 ? <th>{i.occName}</th> : <td>{i.occName}</td>
-                    }
-                    <td style={{textAlign: "right"}}>{i.women}</td>
-                    <td style={{textAlign: "right"}}>{i.men}</td>
-                    <td style={{textAlign: "right"}}>{i.total}</td>
-                  </tr>
-                )
-              }
-              </tbody>
-            </table>
-          </Card.Body>
-        </Card>
-      )
-    }
+          </tbody>
+        </table>
+      </Card.Body>
+    </Card>
+  );
 }
 
 export default UnitView;

--- a/exercises/part2/src/react/hello.md
+++ b/exercises/part2/src/react/hello.md
@@ -19,37 +19,30 @@ First, strip out the sample code so your `App.js` file looks like this:
 import './App.css';
 import React from 'react';
 
-class App extends React.Component {
-  render() {
-    return (
-      <p>App</p>
-    )
-  }
+function App() {
+  return (
+    <p>App</p>
+  )
 }
 
 export default App;
 ```
 
-Save the file - if the `npm run` server is running in another window, it will reload - and check that you get a page with just the text `App`.
+Save the file - if the `npm start` server is running in another window, it will reload - and check that you get a page with just the text `App`.
 
 ## Add some state
 
-In the app class, we can add some state such as a name field:
+In the app component, we can add some state such as a name field:
 
 ```js
 import './App.css';
 import React from 'react';
 
-class App extends React.Component {
-  state = {
-    name: 'David'
-  }
-
-  render() {
-    return (
-      <p>Hello, {this.state.name}!</p>
-    )
-  }
+function App() {
+  const name = "David";
+  return (
+    <p>Hello, {name}!</p>
+  )
 }
 
 export default App;
@@ -59,21 +52,21 @@ Check that this now displays `Hello, David!`.
 
 ## Pass state between Components
 
-Let's make a separate component to display the name - add this class before the `export default` line:
+Let's make a separate component to display the name - add this function before the `export default` line:
 
 ```js
-class NameGreeter extends React.Component {
-  render() {
-    if (this.props.name === "") {
-      return (
-        <p>Hello!</p>
-      )
-    } else {
-      return (
-        <p>Hello, {this.props.name}!</p>
-      )
-    }
+function NameGreeter({ name }) {
+  if (name === "") {
+    return (
+      <p>Hello!</p>
+    )
+  } else {
+    return (
+      <p>Hello, {name}!</p>
+    )
   }
+  // you can also write this as a single expression:
+  // return name === "" ? <p>Hello!</p> : <p>Hello, {name}!</p>
 }
 ```
 
@@ -82,24 +75,20 @@ This component expects one property (the react version of a "parameter") called 
 Change the render method for the App class to this:
 
 ```js
-render() {
-  return (
-    <NameGreeter name={this.state.name} />
-  )
-}
+return (
+  <NameGreeter name={name} />
+)
 ```
 
 This tells react that when it's time to render the App, it should create a `NameGreeter` component and pass it one prop called `name` which has the value of the name in the current state.
-
-Note how we refer to `this.state.name` in the component that owns the state, but `this.props.name` in the child component. Generally, `this.state` is a component's own state and `this.props` is state (or other things) that a component gets from its parent.
 
 You could try making more than one name greeter, but a JSX block must always have a single root tag so this won't work:
 
 ```js
 // don't do this
 return (
-  <NameGreeter name={this.state.name} />
-  <NameGreeter name={this.state.name} />
+  <NameGreeter name={name} />
+  <NameGreeter name={name} />
 )
 ```
 
@@ -107,10 +96,10 @@ But this is fine:
 
 ```js
 return (
-  <div>
-    <NameGreeter name={this.state.name} />
-    <NameGreeter name={this.state.name} />
-  </div>
+  <div> {/*or <>*/}
+    <NameGreeter name={name} />
+    <NameGreeter name={name} />
+  </div> {/*or </>*/}
 )
 ```
 
@@ -122,16 +111,18 @@ However, the name _belongs_ to the app component: this is the _state lifting_ pa
 First, create a new component like this:
 
 ```js
-class NameEditor extends React.Component {
-  render() {
-    return (
-      <p>
-        <label for="name">Name: </label>
-        <input type="text" id="name" value={this.props.name} />
-      </p>
-    )
-  }
+// your NameGreeter...
+
+function NameEditor({ name }) {
+  return (
+    <p>
+      <label htmlFor="name">Name: </label>
+      <input type="text" id="name" value={name} />
+    </p>
+  )
 }
+
+// your App...
 ```
 
 And change the render method of the `App` component to create a name editor:
@@ -139,10 +130,10 @@ And change the render method of the `App` component to create a name editor:
 ```js
 return (
   <div>
-    <NameEditor name={this.state.name} />
-    <NameGreeter name={this.state.name} />
+    <NameEditor name={name} />
+    <NameGreeter name={name} />
   </div>
-)
+
 ```
 
 When you run this, it will show you an input box with the current name, but if you try and change it then React will change it straight back again.
@@ -152,56 +143,48 @@ Input and output in React works with _data binding_: react maintains the corresp
 To make the edit box work, we have to first create a function on the `App` component that allows the state to be updated:
 
 ```js
-class App extends React.Component {
-  constructor() {
-    super();
-    this.onNameChange = this.onNameChange.bind(this);
-  }
+// add useState to the import list
+import React, { useState } from 'react';
 
-  onNameChange(newName) {
-        this.setState({name: newName})
+function App() {
+  // const name = "David";
+  const [name, setName] = useState("David");
+
+  const onNameChange = (e) => {
+    setName(e.target.value);
   }
 
   // state and render method here, same as before
 }
 ```
 
-The real work is happening in `this.setState`, we can't just do `this.state.name = newName` as that would not trigger React's updates. The `setState` function which is part of React, apart from setting the new state, also re-renders any component that needs to update itself.
-
-The constructor is just boilerplate code to correctly re-bind the `this` variable for `onNameChange`, you have to do this for every method you write in a React class. You also need to call the `super()` constructor explicitly at the start of the constructor, as this calls the `React.Component` constructor to set the component up correctly.
+The real work is happening in `setName`, we can't just do `name = newName` as that would not trigger React's updates. The `setName` function which is part of React, apart from setting the new state, also re-renders any component that needs to update itself.
 
 We also have to let the name editor know which function to call to process changes. Change the JSX line that creates it to
 
-```html
-<NameEditor name={this.state.name} onNameChange={this.onNameChange} />
+```js
+<NameEditor name={name} onNameChange={onNameChange} />
 ```
 
 We did not put brackets after the function name, as we don't want to call the function when the component is created or rendered, we just want to tell it "here's a function that you can call later when you need it".
 
-Next, in the `NameEditor` class, we create a method to handle updates:
+Next, in the `NameEditor` class, we call `onNameChange` using the `onChange` attribute for the `<input>` element, which is defined in the HTML standard to handle updates and takes a JavaScript function that should be called whenever the input value changes:
 
 ```js
-constructor(props) {
-  super(props);
-  this.onNameChange = this.onNameChange.bind(this);
-}
-
-onNameChange(e) {
-  this.props.onNameChange(e.target.value);
+function NameEditor({ name, onNameChange }) {
+  return (
+    <p>
+      <label htmlFor="name">Name: </label>
+      {/* Before */}
+      {/* <input type="text" id="name" value={name}/> */}
+      {/* After */}
+      <input type="text" id="name" value={name} onChange={(e)=>{onNameChange(e)}} />
+    </p>
+  )
 }
 ```
 
-If our component takes props, then we should pass them to the super constructor too.
-
-The parameter `e` is an element of type event, which is triggered by the input component when the user changes its value. The event class has a property `target` which refers to the element on the page that triggered it, and if that was an input box like it is here then we can read its `value`. This is what we pass, via `props`, back to the `App` component.
-
-Finally, change the line that creates the input box to
-
-```html
-<input type="text" id="name" value={this.props.name} onChange={this.onNameChange} />
-```
-
-The `onChange` attribute of an `<input>` is defined in the HTML standard and takes a JavaScript function that should be called whenever the input value changes.
+The parameter `e` is an element of type event, which is triggered by the input component when the user changes its value. The event class has a property `target` which refers to the element on the page that triggered it, and if that was an input box like it is here then we can read its `value`. This is what we pass, via `name`, back to the `App` component.
 
 With all this in place, you should be able to run the app and edit the text box, and watch the greeting change as you do this.
 
@@ -212,9 +195,9 @@ Make sure you understand what happens when you type in the input box. You can ob
   1. You type in the input box.
   2. The browser reacts by calling the input box's `onChange` function with one parameter, an `Event`. This function is `NameEditor.onNameChange`.
   3. Your `NameEditor.onNameChange` calls `App.onNameChange`.
-  4. `App.onNameChange` calls React's `setState`.
-  5. In response to this, React calls `render()` on the `App`.
-  6. This triggers further `render()` calls in both `NameGreeter` and `NameEditor`.
+  4. `App.onNameChange` calls React's `setName`.
+  5. In response to this, React calls `retrn()` on the `App`.
+  6. This triggers further `return()` calls in both `NameGreeter` and `NameEditor`.
 
 ## Build the app
 


### PR DESCRIPTION
## Context

The current syntax for the React exercises is from pre-v16.8, which uses class-based components instead of javascript-like declarations and hooks like the current version. 

While the current exercises are still valid (you can write the code and it'd still work), the official React documentation no longer recommends this since 2019.  See [this](https://beta.reactjs.org/reference/react/Component):

<img width="909" alt="Screenshot 2023-03-16 at 14 34 06" src="https://user-images.githubusercontent.com/19511562/225650476-a71ac662-8aa4-44f6-a593-569edb9a9faf.png">

## Changes made

- Edited [Part 2, Week 9, Section 7.2](https://cs-uob.github.io/COMSM0085/exercises/part2/react/hello.html)
- Edited [Part 2, Week 10](https://cs-uob.github.io/COMSM0085/exercises/part2/app1/index.html) 
- Edited `code/application/client` to use React hooks and functions for componenents
